### PR TITLE
歴史作品の追加とズーム時の表示修正

### DIFF
--- a/public/data.json
+++ b/public/data.json
@@ -42,7 +42,16 @@
       "title": "殷（商）王朝の滅亡",
       "description": "暴君・紂王が周の武王に牧野の戦いで敗れ滅亡。殷は約550年続いた。",
       "links": ["https://ja.wikipedia.org/wiki/%E6%AE%B7"],
-      "media": []
+      "media": [
+        {
+          "title": "封神演義",
+          "type": "manga",
+          "remark": "藤崎竜作。殷周革命を舞台にした神怪ファンタジー",
+          "coverageStartYear": -1100,
+          "coverageEndYear": -1046,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E5%B0%81%E7%A5%9E%E6%BC%94%E7%BE%A9+%E8%97%A4%E5%B4%8E%E7%AB%9C+Kindle"
+        }
+      ]
     },
     {
       "id": "china-western-zhou-start",
@@ -75,7 +84,16 @@
       "title": "春秋時代の開始",
       "description": "周の平王が洛邑（洛陽）へ遷都。東周の始まりとともに春秋時代が開始。諸侯国が覇を競う時代。",
       "links": ["https://ja.wikipedia.org/wiki/%E6%98%A5%E7%A7%8B%E6%99%82%E4%BB%A3"],
-      "media": []
+      "media": [
+        {
+          "title": "東周英雄伝",
+          "type": "manga",
+          "remark": "鄭問作。春秋戦国時代の英雄たちを描く",
+          "coverageStartYear": -770,
+          "coverageEndYear": -221,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E6%9D%B1%E5%91%A8%E8%8B%B1%E9%9B%84%E4%BC%9D+%E9%84%AD%E5%95%8F+Kindle"
+        }
+      ]
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440020",
@@ -105,6 +123,38 @@
           "coverageStartYear": -259,
           "coverageEndYear": -221,
           "kindleUrl": "https://www.amazon.co.jp/s?k=%E3%82%AD%E3%83%B3%E3%82%B0%E3%83%80%E3%83%A0+%E5%8E%9F%E6%B3%B0%E4%B9%85+Kindle"
+        },
+        {
+          "title": "史記",
+          "type": "manga",
+          "remark": "横山光輝作。司馬遷の史記を漫画化",
+          "coverageStartYear": -403,
+          "coverageEndYear": -91,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E5%8F%B2%E8%A8%98+%E6%A8%AA%E5%B1%B1%E5%85%89%E8%BC%9D+Kindle"
+        },
+        {
+          "title": "達人伝",
+          "type": "manga",
+          "remark": "王欣太作。荘子を主人公に戦国時代を描く",
+          "coverageStartYear": -369,
+          "coverageEndYear": -286,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E9%81%94%E4%BA%BA%E4%BC%9D+%E7%8E%8B%E6%AC%A3%E5%A4%AA+Kindle"
+        },
+        {
+          "title": "墨攻",
+          "type": "manga",
+          "remark": "森秀樹作、酒見賢一原作。墨家の守城術と秦の統一戦争を描く",
+          "coverageStartYear": -260,
+          "coverageEndYear": -221,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E5%A2%A8%E6%94%BB+%E6%A3%AE%E7%A7%80%E6%A8%B9+Kindle"
+        },
+        {
+          "title": "名人伝",
+          "type": "novel",
+          "remark": "中島敦作。列子を原典とした弓の名人の物語",
+          "coverageStartYear": -400,
+          "coverageEndYear": -350,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E5%90%8D%E4%BA%BA%E4%BC%9D+%E4%B8%AD%E5%B3%B6%E6%95%A6+Kindle"
         }
       ]
     },
@@ -407,7 +457,16 @@
       "title": "唐の成立",
       "description": "李淵（高祖）が唐を建国。長安を都とし、中国史上最も繁栄した時代の一つとなる。",
       "links": ["https://ja.wikipedia.org/wiki/%E5%94%90"],
-      "media": []
+      "media": [
+        {
+          "title": "山月記",
+          "type": "novel",
+          "remark": "中島敦作。唐代天宝年間、虎に変じた詩人李徴の物語",
+          "coverageStartYear": 740,
+          "coverageEndYear": 756,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E5%B1%B1%E6%9C%88%E8%A8%98+%E4%B8%AD%E5%B3%B6%E6%95%A6+Kindle"
+        }
+      ]
     },
     {
       "id": "china-tang-end",
@@ -619,6 +678,26 @@
       "media": []
     },
     {
+      "id": "china-cultural-revolution",
+      "year": 1966,
+      "yearDisplay": "1966年",
+      "era": "中華人民共和国",
+      "region": "china",
+      "title": "文化大革命",
+      "description": "毛沢東が発動した政治運動。紅衛兵による知識人迫害など、約10年にわたり中国社会に大きな影響を与えた。",
+      "links": ["https://ja.wikipedia.org/wiki/%E6%96%87%E5%8C%96%E5%A4%A7%E9%9D%A9%E5%91%BD"],
+      "media": [
+        {
+          "title": "三体",
+          "type": "novel",
+          "remark": "劉慈欣作。文化大革命から始まり、宇宙規模の物語へ発展する壮大なSF",
+          "coverageStartYear": 1967,
+          "coverageEndYear": 2400,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E4%B8%89%E4%BD%93+%E5%8A%89%E6%85%88%E6%AC%A3+Kindle"
+        }
+      ]
+    },
+    {
       "id": "550e8400-e29b-41d4-a716-446655440030",
       "year": -509,
       "yearDisplay": "前509年",
@@ -627,7 +706,64 @@
       "title": "共和政ローマの成立",
       "description": "ローマ王タルクィニウス・スペルブスを追放し、貴族による共和政が始まる。",
       "links": ["https://ja.wikipedia.org/wiki/%E5%85%B1%E5%92%8C%E6%94%BF%E3%83%AD%E3%83%BC%E3%83%9E"],
-      "media": []
+      "media": [
+        {
+          "title": "ヒストリエ",
+          "type": "manga",
+          "remark": "岩明均作。マケドニアのエウメネスの生涯を描く",
+          "coverageStartYear": -362,
+          "coverageEndYear": -316,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E3%83%92%E3%82%B9%E3%83%88%E3%83%AA%E3%82%A8+%E5%B2%A9%E6%98%8E%E5%9D%87+Kindle"
+        },
+        {
+          "title": "ヘウレーカ",
+          "type": "manga",
+          "remark": "岩明均作。シラクサ包囲戦とアルキメデスを描く",
+          "coverageStartYear": -214,
+          "coverageEndYear": -212,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E3%83%98%E3%82%A6%E3%83%AC%E3%83%BC%E3%82%AB+%E5%B2%A9%E6%98%8E%E5%9D%87+Kindle"
+        },
+        {
+          "title": "ブッダ",
+          "type": "manga",
+          "remark": "手塚治虫作。釈迦の生涯を描く大長編",
+          "coverageStartYear": -566,
+          "coverageEndYear": -486,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E3%83%96%E3%83%83%E3%83%80+%E6%89%8B%E5%A1%9A%E6%B2%BB%E8%99%AB+Kindle"
+        },
+        {
+          "title": "アド・アストラ",
+          "type": "manga",
+          "remark": "カガノミハチ作。第二次ポエニ戦争、スキピオとハンニバルを描く",
+          "coverageStartYear": -218,
+          "coverageEndYear": -201,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E3%82%A2%E3%83%89%E3%83%BB%E3%82%A2%E3%82%B9%E3%83%88%E3%83%A9+%E3%82%AB%E3%82%AC%E3%83%8E%E3%83%9F%E3%83%8F%E3%83%81+Kindle"
+        },
+        {
+          "title": "火の鳥 エジプト編",
+          "type": "manga",
+          "remark": "手塚治虫作。古代エジプトを舞台にした少女クラブ版",
+          "coverageStartYear": -1500,
+          "coverageEndYear": -1200,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%81%AB%E3%81%AE%E9%B3%A5+%E3%82%A8%E3%82%B8%E3%83%97%E3%83%88%E7%B7%A8+Kindle"
+        },
+        {
+          "title": "火の鳥 ギリシャ編",
+          "type": "manga",
+          "remark": "手塚治虫作。古代ギリシャを舞台にした少女クラブ版",
+          "coverageStartYear": -500,
+          "coverageEndYear": -400,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%81%AB%E3%81%AE%E9%B3%A5+%E3%82%AE%E3%83%AA%E3%82%B7%E3%83%A3%E7%B7%A8+Kindle"
+        },
+        {
+          "title": "火の鳥 ローマ編",
+          "type": "manga",
+          "remark": "手塚治虫作。古代ローマを舞台にした少女クラブ版",
+          "coverageStartYear": -100,
+          "coverageEndYear": 100,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%81%AB%E3%81%AE%E9%B3%A5+%E3%83%AD%E3%83%BC%E3%83%9E%E7%B7%A8+Kindle"
+        }
+      ]
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440006",
@@ -692,6 +828,26 @@
       "description": "ゲルマン人傭兵隊長オドアケルにより最後の西ローマ皇帝ロムルス・アウグストゥルスが廃位。西ローマ帝国が滅亡。",
       "links": ["https://ja.wikipedia.org/wiki/%E8%A5%BF%E3%83%AD%E3%83%BC%E3%83%9E%E5%B8%9D%E5%9B%BD"],
       "media": []
+    },
+    {
+      "id": "europe-french-revolution",
+      "year": 1789,
+      "yearDisplay": "1789年",
+      "era": "フランス革命",
+      "region": "europe",
+      "title": "フランス革命",
+      "description": "バスティーユ牢獄襲撃により勃発。絶対王政が崩壊し、近代市民社会の幕開けとなる。",
+      "links": ["https://ja.wikipedia.org/wiki/%E3%83%95%E3%83%A9%E3%83%B3%E3%82%B9%E9%9D%A9%E5%91%BD"],
+      "media": [
+        {
+          "title": "ベルサイユのばら",
+          "type": "manga",
+          "remark": "池田理代子作。フランス革命前夜のベルサイユ宮殿を舞台にオスカルとマリー・アントワネットを描く",
+          "coverageStartYear": 1755,
+          "coverageEndYear": 1793,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E3%83%99%E3%83%AB%E3%82%B5%E3%82%A4%E3%83%A6%E3%81%AE%E3%81%B0%E3%82%89+Kindle"
+        }
+      ]
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440007",
@@ -768,7 +924,24 @@
       "title": "古墳時代の開始",
       "description": "大規模な前方後円墳が造られ始める。大和政権が成立。",
       "links": ["https://ja.wikipedia.org/wiki/%E5%8F%A4%E5%A2%B3%E6%99%82%E4%BB%A3"],
-      "media": []
+      "media": [
+        {
+          "title": "火の鳥 黎明編",
+          "type": "manga",
+          "remark": "手塚治虫作。邪馬台国時代を舞台に永遠の命を求める物語",
+          "coverageStartYear": 240,
+          "coverageEndYear": 270,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%81%AB%E3%81%AE%E9%B3%A5+%E9%BB%8E%E6%98%8E%E7%B7%A8+Kindle"
+        },
+        {
+          "title": "火の鳥 ヤマト編",
+          "type": "manga",
+          "remark": "手塚治虫作。ヤマトタケルの時代を描く",
+          "coverageStartYear": 350,
+          "coverageEndYear": 400,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%81%AB%E3%81%AE%E9%B3%A5+%E3%83%A4%E3%83%9E%E3%83%88%E7%B7%A8+Kindle"
+        }
+      ]
     },
     {
       "id": "japan-kofun-end",
@@ -801,7 +974,16 @@
       "title": "大化の改新",
       "description": "中大兄皇子と中臣鎌足が蘇我氏を滅ぼし、律令国家建設を目指す改革を開始。",
       "links": ["https://ja.wikipedia.org/wiki/%E5%A4%A7%E5%8C%96%E3%81%AE%E6%94%B9%E6%96%B0"],
-      "media": []
+      "media": [
+        {
+          "title": "火の鳥 太陽編",
+          "type": "manga",
+          "remark": "手塚治虫作。白村江の戦い前後と未来を描く二重構造",
+          "coverageStartYear": 661,
+          "coverageEndYear": 672,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%81%AB%E3%81%AE%E9%B3%A5+%E5%A4%AA%E9%99%BD%E7%B7%A8+Kindle"
+        }
+      ]
     },
     {
       "id": "japan-asuka-end",
@@ -823,7 +1005,24 @@
       "title": "奈良時代の開始",
       "description": "元明天皇が平城京に遷都。律令制が完成し、天平文化が栄える。",
       "links": ["https://ja.wikipedia.org/wiki/%E5%A5%88%E8%89%AF%E6%99%82%E4%BB%A3"],
-      "media": []
+      "media": [
+        {
+          "title": "火の鳥 鳳凰編",
+          "type": "manga",
+          "remark": "手塚治虫作。奈良時代の仏師我王と茜丸の物語",
+          "coverageStartYear": 720,
+          "coverageEndYear": 760,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%81%AB%E3%81%AE%E9%B3%A5+%E9%B3%B3%E5%87%B0%E7%B7%A8+Kindle"
+        },
+        {
+          "title": "火の鳥 羽衣編",
+          "type": "manga",
+          "remark": "手塚治虫作。天女伝説をモチーフにした平安時代中期の物語",
+          "coverageStartYear": 950,
+          "coverageEndYear": 1000,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%81%AB%E3%81%AE%E9%B3%A5+%E7%BE%BD%E8%A1%A3%E7%B7%A8+Kindle"
+        }
+      ]
     },
     {
       "id": "japan-nara-end",
@@ -845,7 +1044,24 @@
       "title": "平安時代の開始",
       "description": "桓武天皇が平安京（京都）に遷都。摂関政治や国風文化が発展。",
       "links": ["https://ja.wikipedia.org/wiki/%E5%B9%B3%E5%AE%89%E6%99%82%E4%BB%A3"],
-      "media": []
+      "media": [
+        {
+          "title": "童の神",
+          "type": "manga",
+          "remark": "今村翔吾原作、深谷陽作画。酒呑童子伝説を基にした平安時代の物語",
+          "coverageStartYear": 990,
+          "coverageEndYear": 1020,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%AB%A5%E3%81%AE%E7%A5%9E+%E6%BC%AB%E7%94%BB+Kindle"
+        },
+        {
+          "title": "あさきゆめみし",
+          "type": "manga",
+          "remark": "大和和紀作。源氏物語を漫画化した平安絵巻",
+          "coverageStartYear": 970,
+          "coverageEndYear": 1020,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E3%81%82%E3%81%95%E3%81%8D%E3%82%86%E3%82%81%E3%81%BF%E3%81%97+%E5%A4%A7%E5%92%8C%E5%92%8C%E7%B4%80+Kindle"
+        }
+      ]
     },
     {
       "id": "japan-heian-end",
@@ -867,7 +1083,16 @@
       "title": "鎌倉時代の開始",
       "description": "壇ノ浦の戦いで平氏が滅亡。源頼朝が守護・地頭の設置権を獲得し、実質的な武家政権が成立。",
       "links": ["https://ja.wikipedia.org/wiki/%E9%8E%8C%E5%80%89%E6%99%82%E4%BB%A3"],
-      "media": []
+      "media": [
+        {
+          "title": "火の鳥 乱世編",
+          "type": "manga",
+          "remark": "手塚治虫作。源平合戦の時代を描く",
+          "coverageStartYear": 1159,
+          "coverageEndYear": 1189,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%81%AB%E3%81%AE%E9%B3%A5+%E4%B9%B1%E4%B8%96%E7%B7%A8+Kindle"
+        }
+      ]
     },
     {
       "id": "550e8400-e29b-41d4-a716-446655440005",
@@ -897,7 +1122,16 @@
       "title": "鎌倉幕府の滅亡",
       "description": "後醍醐天皇による倒幕運動により、新田義貞が鎌倉を攻略。北条高時が自害し鎌倉幕府が滅亡。",
       "links": ["https://ja.wikipedia.org/wiki/%E9%8E%8C%E5%80%89%E5%B9%95%E5%BA%9C"],
-      "media": []
+      "media": [
+        {
+          "title": "逃げ上手の若君",
+          "type": "manga",
+          "remark": "松井優征作。北条時行の生涯を描く歴史スペクタクル",
+          "coverageStartYear": 1333,
+          "coverageEndYear": 1353,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E9%80%83%E3%81%92%E4%B8%8A%E6%89%8B%E3%81%AE%E8%8B%A5%E5%90%9B+Kindle"
+        }
+      ]
     },
     {
       "id": "japan-kenmu-start",
@@ -963,7 +1197,24 @@
       "title": "応仁の乱・戦国時代の開始",
       "description": "応仁の乱が勃発。室町幕府の権威が失墜し、各地で戦国大名が台頭する戦国時代が始まる。",
       "links": ["https://ja.wikipedia.org/wiki/%E6%88%A6%E5%9B%BD%E6%99%82%E4%BB%A3_(%E6%97%A5%E6%9C%AC)"],
-      "media": []
+      "media": [
+        {
+          "title": "火の鳥 異形編",
+          "type": "manga",
+          "remark": "手塚治虫作。室町時代を舞台にした怪異譚",
+          "coverageStartYear": 1470,
+          "coverageEndYear": 1490,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%81%AB%E3%81%AE%E9%B3%A5+%E7%95%B0%E5%BD%A2%E7%B7%A8+Kindle"
+        },
+        {
+          "title": "チ。―地球の運動について―",
+          "type": "manga",
+          "remark": "魚豊作。15世紀ポーランドを舞台に地動説を追う者たちを描く",
+          "coverageStartYear": 1400,
+          "coverageEndYear": 1500,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E3%83%81%E3%80%82+%E5%9C%B0%E7%90%83%E3%81%AE%E9%81%8B%E5%8B%95%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6+Kindle"
+        }
+      ]
     },
     {
       "id": "japan-muromachi-end",
@@ -1004,6 +1255,46 @@
           "coverageStartYear": 1560,
           "coverageEndYear": 1600,
           "kindleUrl": "https://www.amazon.co.jp/s?k=%E3%82%BB%E3%83%B3%E3%82%B4%E3%82%AF+%E5%AE%AE%E4%B8%8B%E8%8B%B1%E6%A8%B9+Kindle"
+        },
+        {
+          "title": "花の慶次",
+          "type": "manga",
+          "remark": "隆慶一郎原作、原哲夫作画。前田慶次の生涯を描く",
+          "coverageStartYear": 1560,
+          "coverageEndYear": 1612,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E8%8A%B1%E3%81%AE%E6%85%B6%E6%AC%A1+%E5%8E%9F%E5%93%B2%E5%A4%AB+Kindle"
+        },
+        {
+          "title": "殺っちゃえ！！宇喜多さん",
+          "type": "manga",
+          "remark": "重野なおき作。宇喜多直家の生涯を描く4コマ漫画",
+          "coverageStartYear": 1529,
+          "coverageEndYear": 1582,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E6%AE%BA%E3%81%A3%E3%81%A1%E3%82%83%E3%81%88+%E5%AE%87%E5%96%9C%E5%A4%9A%E3%81%95%E3%82%93+Kindle"
+        },
+        {
+          "title": "へうげもの",
+          "type": "manga",
+          "remark": "山田芳裕作。古田織部を主人公に戦国の数寄者を描く",
+          "coverageStartYear": 1582,
+          "coverageEndYear": 1615,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E3%81%B8%E3%81%86%E3%81%92%E3%82%82%E3%81%AE+Kindle"
+        },
+        {
+          "title": "忍びの国",
+          "type": "novel",
+          "remark": "和田竜作。天正伊賀の乱を描く忍者小説",
+          "coverageStartYear": 1579,
+          "coverageEndYear": 1581,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E5%BF%8D%E3%81%B3%E3%81%AE%E5%9B%BD+%E5%92%8C%E7%94%B0%E7%AB%9C+Kindle"
+        },
+        {
+          "title": "覇王の家",
+          "type": "novel",
+          "remark": "司馬遼太郎作。徳川家康の生涯を描く",
+          "coverageStartYear": 1542,
+          "coverageEndYear": 1584,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E8%A6%87%E7%8E%8B%E3%81%AE%E5%AE%B6+%E5%8F%B8%E9%A6%AC%E9%81%BC%E5%A4%AA%E9%83%8E+Kindle"
         }
       ]
     },
@@ -1038,7 +1329,24 @@
       "title": "江戸時代の開始",
       "description": "徳川家康が征夷大将軍に任命され、江戸幕府を開く。約260年続く太平の世が始まる。",
       "links": ["https://ja.wikipedia.org/wiki/%E6%B1%9F%E6%88%B8%E6%99%82%E4%BB%A3"],
-      "media": []
+      "media": [
+        {
+          "title": "影武者徳川家康",
+          "type": "novel",
+          "remark": "隆慶一郎作。関ヶ原で家康が暗殺され、影武者が成り代わる物語",
+          "coverageStartYear": 1600,
+          "coverageEndYear": 1616,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E5%BD%B1%E6%AD%A6%E8%80%85%E5%BE%B3%E5%B7%9D%E5%AE%B6%E5%BA%B7+%E9%9A%86%E6%85%B6%E4%B8%80%E9%83%8E+Kindle"
+        },
+        {
+          "title": "シグルイ",
+          "type": "manga",
+          "remark": "山口貴由作、南條範夫原作。寛永6年駿河城御前試合を描く",
+          "coverageStartYear": 1629,
+          "coverageEndYear": 1629,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E3%82%B7%E3%82%B0%E3%83%AB%E3%82%A4+Kindle"
+        }
+      ]
     },
     {
       "id": "japan-edo-end",
@@ -1060,7 +1368,48 @@
       "title": "明治時代の開始",
       "description": "明治維新により近代国家建設が始まる。廃藩置県や文明開化が進む。",
       "links": ["https://ja.wikipedia.org/wiki/%E6%98%8E%E6%B2%BB%E6%99%82%E4%BB%A3"],
-      "media": []
+      "media": [
+        {
+          "title": "るろうに剣心",
+          "type": "manga",
+          "remark": "和月伸宏作。幕末から明治初期を舞台に緋村剣心を描く",
+          "coverageStartYear": 1878,
+          "coverageEndYear": 1879,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E3%82%8B%E3%82%8D%E3%81%86%E3%81%AB%E5%89%A3%E5%BF%83+Kindle"
+        },
+        {
+          "title": "燃えよ剣",
+          "type": "novel",
+          "remark": "司馬遼太郎作。新選組副長・土方歳三の生涯を描く",
+          "coverageStartYear": 1863,
+          "coverageEndYear": 1869,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%87%83%E3%81%88%E3%82%88%E5%89%A3+%E5%8F%B8%E9%A6%AC%E9%81%BC%E5%A4%AA%E9%83%8E+Kindle"
+        },
+        {
+          "title": "竜馬がゆく",
+          "type": "novel",
+          "remark": "司馬遼太郎作。幕末の志士・坂本龍馬の生涯を描く",
+          "coverageStartYear": 1853,
+          "coverageEndYear": 1867,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%AB%9C%E9%A6%AC%E3%81%8C%E3%82%86%E3%81%8F+%E5%8F%B8%E9%A6%AC%E9%81%BC%E5%A4%AA%E9%83%8E+Kindle"
+        },
+        {
+          "title": "ゴールデンカムイ",
+          "type": "manga",
+          "remark": "野田サトル作。日露戦争後の北海道を舞台にアイヌの金塊を巡る物語",
+          "coverageStartYear": 1905,
+          "coverageEndYear": 1908,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E3%82%B4%E3%83%BC%E3%83%AB%E3%83%87%E3%83%B3%E3%82%AB%E3%83%A0%E3%82%A4+Kindle"
+        },
+        {
+          "title": "松かげに憩う",
+          "type": "manga",
+          "remark": "雨瀬シオリ作。幕末の教育者・吉田松陰の生涯を描く",
+          "coverageStartYear": 1830,
+          "coverageEndYear": 1859,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E6%9D%BE%E3%81%8B%E3%81%92%E3%81%AB%E6%86%A9%E3%81%86+Kindle"
+        }
+      ]
     },
     {
       "id": "japan-meiji-end",
@@ -1082,7 +1431,16 @@
       "title": "大正時代の開始",
       "description": "大正天皇が即位。大正デモクラシーと呼ばれる民主主義運動が活発化。",
       "links": ["https://ja.wikipedia.org/wiki/%E5%A4%A7%E6%AD%A3%E6%99%82%E4%BB%A3"],
-      "media": []
+      "media": [
+        {
+          "title": "鬼滅の刃",
+          "type": "manga",
+          "remark": "吾峠呼世晴作。大正時代を舞台に鬼殺隊の戦いを描く",
+          "coverageStartYear": 1912,
+          "coverageEndYear": 1916,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E9%AC%BC%E6%BB%85%E3%81%AE%E5%88%83+Kindle"
+        }
+      ]
     },
     {
       "id": "japan-taisho-end",
@@ -1148,7 +1506,56 @@
       "title": "令和時代の開始",
       "description": "徳仁天皇が即位し、令和時代が始まる。コロナ禍を経験した新時代。",
       "links": ["https://ja.wikipedia.org/wiki/%E4%BB%A4%E5%92%8C%E6%99%82%E4%BB%A3"],
-      "media": []
+      "media": [
+        {
+          "title": "プロジェクト・ヘイル・メアリー",
+          "type": "novel",
+          "remark": "アンディ・ウィアー作。太陽の異変を止めるため宇宙へ旅立つ近未来SF",
+          "coverageStartYear": 2025,
+          "coverageEndYear": 2040,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%83%BB%E3%83%98%E3%82%A4%E3%83%AB%E3%83%BB%E3%83%A1%E3%82%A2%E3%83%AA%E3%83%BC+Kindle"
+        },
+        {
+          "title": "火の鳥 未来編",
+          "type": "manga",
+          "remark": "手塚治虫作。遠未来の地球滅亡と再生を描く",
+          "coverageStartYear": 3404,
+          "coverageEndYear": 3404,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%81%AB%E3%81%AE%E9%B3%A5+%E6%9C%AA%E6%9D%A5%E7%B7%A8+Kindle"
+        },
+        {
+          "title": "火の鳥 宇宙編",
+          "type": "manga",
+          "remark": "手塚治虫作。宇宙を舞台にした未来の物語",
+          "coverageStartYear": 2577,
+          "coverageEndYear": 2577,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%81%AB%E3%81%AE%E9%B3%A5+%E5%AE%87%E5%AE%99%E7%B7%A8+Kindle"
+        },
+        {
+          "title": "火の鳥 復活編",
+          "type": "manga",
+          "remark": "手塚治虫作。2482年と3030年を行き来する輪廻転生の物語",
+          "coverageStartYear": 2482,
+          "coverageEndYear": 3030,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%81%AB%E3%81%AE%E9%B3%A5+%E5%BE%A9%E6%B4%BB%E7%B7%A8+Kindle"
+        },
+        {
+          "title": "火の鳥 望郷編",
+          "type": "manga",
+          "remark": "手塚治虫作。惑星エデンでの人類の営みを描く",
+          "coverageStartYear": 2155,
+          "coverageEndYear": 2300,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%81%AB%E3%81%AE%E9%B3%A5+%E6%9C%9B%E9%83%B7%E7%B7%A8+Kindle"
+        },
+        {
+          "title": "火の鳥 生命編",
+          "type": "manga",
+          "remark": "手塚治虫作。クローン技術と生命倫理を描く",
+          "coverageStartYear": 2155,
+          "coverageEndYear": 2155,
+          "kindleUrl": "https://www.amazon.co.jp/s?k=%E7%81%AB%E3%81%AE%E9%B3%A5+%E7%94%9F%E5%91%BD%E7%B7%A8+Kindle"
+        }
+      ]
     }
   ]
 }

--- a/src/components/timeline/EraLane.vue
+++ b/src/components/timeline/EraLane.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { EraLaneData } from '@/types/timeline'
 
 const props = defineProps<{
@@ -6,7 +7,11 @@ const props = defineProps<{
   y: number
   height: number
   yearToPosition: (year: number) => number
+  scale: number
 }>()
+
+// テキストの逆スケール変換
+const textTransform = computed(() => `scaleX(${1 / props.scale})`)
 
 const emit = defineEmits<{
   (e: 'click', event: MouseEvent): void
@@ -57,6 +62,7 @@ const width = props.yearToPosition(props.lane.endYear) - x
       :y="y + height / 2 + 4"
       text-anchor="middle"
       class="pointer-events-none fill-gray-700 text-xs font-medium"
+      :style="{ transform: textTransform, transformOrigin: `${x + Math.max(width, 20) / 2}px ${y + height / 2 + 4}px` }"
     >
       {{ lane.era }}
     </text>

--- a/src/components/timeline/EventMarker.vue
+++ b/src/components/timeline/EventMarker.vue
@@ -1,10 +1,18 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { EventMarkerData } from '@/types/timeline'
 
-defineProps<{
+const props = defineProps<{
   marker: EventMarkerData
   y: number
+  scale: number
 }>()
+
+// テキストの逆スケール変換
+const textTransform = computed(() => `scaleX(${1 / props.scale})`)
+
+// 菱形の横幅を逆スケールで調整（scaleX後も一定のサイズになるように）
+const diamondOffset = computed(() => 8 / props.scale)
 
 const emit = defineEmits<{
   (e: 'click', event: MouseEvent): void
@@ -18,7 +26,7 @@ const emit = defineEmits<{
   >
     <!-- マーカー（菱形） -->
     <polygon
-      :points="`${marker.position},${y} ${marker.position + 8},${y + 8} ${marker.position},${y + 16} ${marker.position - 8},${y + 8}`"
+      :points="`${props.marker.position},${props.y} ${props.marker.position + diamondOffset},${props.y + 8} ${props.marker.position},${props.y + 16} ${props.marker.position - diamondOffset},${props.y + 8}`"
       fill="#ef4444"
       stroke="#b91c1c"
       stroke-width="1"
@@ -26,12 +34,13 @@ const emit = defineEmits<{
     />
     <!-- ラベル -->
     <text
-      :x="marker.position"
-      :y="y + 28"
+      :x="props.marker.position"
+      :y="props.y + 28"
       text-anchor="middle"
       class="pointer-events-none fill-gray-700 text-[10px]"
+      :style="{ transform: textTransform, transformOrigin: `${props.marker.position}px ${props.y + 28}px` }"
     >
-      {{ marker.event.title.length > 8 ? marker.event.title.slice(0, 8) + '...' : marker.event.title }}
+      {{ props.marker.event.title.length > 8 ? props.marker.event.title.slice(0, 8) + '...' : props.marker.event.title }}
     </text>
   </g>
 </template>

--- a/src/components/timeline/MediaLane.vue
+++ b/src/components/timeline/MediaLane.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { MediaLaneData } from '@/types/timeline'
 
 const props = defineProps<{
@@ -6,7 +7,11 @@ const props = defineProps<{
   y: number
   height: number
   yearToPosition: (year: number) => number
+  scale: number
 }>()
+
+// テキストの逆スケール変換
+const textTransform = computed(() => `scaleX(${1 / props.scale})`)
 
 const emit = defineEmits<{
   (e: 'click', event: MouseEvent): void
@@ -62,6 +67,7 @@ const width = hasRange
       text-anchor="middle"
       class="pointer-events-none text-xs font-medium"
       :fill="colors.text"
+      :style="{ transform: textTransform, transformOrigin: `${x + Math.max(width, 40) / 2}px ${y + height / 2 + 4}px` }"
     >
       {{ lane.media.title.length > 10 ? lane.media.title.slice(0, 10) + '...' : lane.media.title }}
     </text>

--- a/src/components/timeline/PersonLane.vue
+++ b/src/components/timeline/PersonLane.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { PersonLaneData } from '@/types/timeline'
 
 const props = defineProps<{
@@ -6,11 +7,15 @@ const props = defineProps<{
   y: number
   height: number
   yearToPosition: (year: number) => number
+  scale: number
 }>()
 
 const emit = defineEmits<{
   (e: 'click', event: MouseEvent): void
 }>()
+
+// テキストの逆スケール変換
+const textTransform = computed(() => `scaleX(${1 / props.scale})`)
 
 const x = props.yearToPosition(props.lane.person.birthYear)
 const width = props.yearToPosition(props.lane.person.deathYear) - x
@@ -37,6 +42,7 @@ const width = props.yearToPosition(props.lane.person.deathYear) - x
       :y="y + height / 2 + 4"
       text-anchor="middle"
       class="pointer-events-none fill-blue-800 text-xs font-medium"
+      :style="{ transform: textTransform, transformOrigin: `${x + Math.max(width, 20) / 2}px ${y + height / 2 + 4}px` }"
     >
       {{ lane.person.name }}
     </text>

--- a/src/components/timeline/PodcastLane.vue
+++ b/src/components/timeline/PodcastLane.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { PodcastLaneData } from '@/types/timeline'
 
 const props = defineProps<{
@@ -6,7 +7,11 @@ const props = defineProps<{
   y: number
   height: number
   yearToPosition: (year: number) => number
+  scale: number
 }>()
+
+// テキストの逆スケール変換
+const textTransform = computed(() => `scaleX(${1 / props.scale})`)
 
 const emit = defineEmits<{
   (e: 'click', event: MouseEvent): void
@@ -55,6 +60,7 @@ const truncatedTitle = displayTitle.length > 15 ? displayTitle.slice(0, 15) + '.
       text-anchor="middle"
       class="pointer-events-none text-xs font-medium"
       :fill="isShort ? colors.shortText : colors.text"
+      :style="{ transform: textTransform, transformOrigin: `${x + width / 2}px ${y + height / 2 + 4}px` }"
     >
       {{ truncatedTitle }}
     </text>

--- a/src/components/timeline/TimelineCanvas.vue
+++ b/src/components/timeline/TimelineCanvas.vue
@@ -348,6 +348,7 @@ const getMediaLaneY = (index: number) => {
                 y="16"
                 text-anchor="middle"
                 class="fill-gray-500 text-xs"
+                :style="{ transform: `scaleX(${1 / scale})`, transformOrigin: `${label.position}px 16px` }"
               >
                 {{ label.label }}
               </text>
@@ -361,6 +362,7 @@ const getMediaLaneY = (index: number) => {
               :x="10"
               :y="(regionHeights[group.region]?.startY ?? 24) + 16"
               class="fill-gray-600 text-xs font-bold"
+              :style="{ transform: `scaleX(${1 / scale})`, transformOrigin: `10px ${(regionHeights[group.region]?.startY ?? 24) + 16}px` }"
             >
               {{ group.regionLabel }}
             </text>
@@ -372,6 +374,7 @@ const getMediaLaneY = (index: number) => {
               :y="getEraLaneY(lane.region, lane.laneIndex)"
               :height="LANE_HEIGHT - 4"
               :year-to-position="yearToPosition"
+              :scale="scale"
               @click="(e) => handleItemClick(e, 'era', lane)"
             />
           </g>
@@ -383,6 +386,7 @@ const getMediaLaneY = (index: number) => {
               :key="marker.event.id"
               :marker="marker"
               :y="getMarkerLaneY(marker.laneIndex)"
+              :scale="scale"
               @click="(e) => handleItemClick(e, 'event', marker.event)"
             />
           </g>
@@ -396,6 +400,7 @@ const getMediaLaneY = (index: number) => {
               :y="getPodcastLaneY(lane.laneIndex)"
               :height="LANE_HEIGHT - 4"
               :year-to-position="yearToPosition"
+              :scale="scale"
               @click="(e) => handleItemClick(e, 'podcast', lane)"
             />
           </g>
@@ -409,6 +414,7 @@ const getMediaLaneY = (index: number) => {
               :y="getPersonLaneY(index)"
               :height="LANE_HEIGHT - 4"
               :year-to-position="yearToPosition"
+              :scale="scale"
               @click="(e) => handleItemClick(e, 'person', lane)"
             />
           </g>
@@ -422,6 +428,7 @@ const getMediaLaneY = (index: number) => {
               :y="getMediaLaneY(index)"
               :height="LANE_HEIGHT - 4"
               :year-to-position="yearToPosition"
+              :scale="scale"
               @click="(e) => handleItemClick(e, 'media', lane)"
             />
           </g>


### PR DESCRIPTION
## Summary
- 新規作品追加: 鬼滅の刃、ゴールデンカムイ、ベルサイユのばら、燃えよ剣、竜馬がゆく、三体、プロジェクト・ヘイル・メアリー、火の鳥（エジプト・ギリシャ・ローマ編）
- 作品情報修正: 松かげに憩う（吉田松陰）、童の神（酒呑童子伝説）
- 新規イベント追加: フランス革命（1789年）、文化大革命（1966年）
- ズーム時にテキストと菱形マーカーが横長になる問題を修正

## Test plan
- [ ] 追加した作品がタイムライン上に正しく表示されることを確認
- [ ] ズーム拡大・縮小時に文字が横長にならないことを確認
- [ ] 菱形マーカーがズーム時も正しい形状を維持することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)