### PR TITLE
fix: GitHub Pages でのデータファイルパスを修正

### DIFF
--- a/src/composables/useAffiliateLink.ts
+++ b/src/composables/useAffiliateLink.ts
@@ -9,7 +9,7 @@ export function useAffiliateLink() {
     if (isLoaded.value) return
 
     try {
-      const response = await fetch('/config.json')
+      const response = await fetch(`${import.meta.env.BASE_URL}config.json`)
       if (response.ok) {
         const config = await response.json()
         if (config.affiliateTag) {

--- a/src/composables/useCotenRadio.ts
+++ b/src/composables/useCotenRadio.ts
@@ -20,7 +20,7 @@ export function useCotenRadio(
     error.value = null
 
     try {
-      const response = await fetch('/coten-radio.json')
+      const response = await fetch(`${import.meta.env.BASE_URL}coten-radio.json`)
       if (!response.ok) {
         throw new Error(`Failed to load: ${response.status}`)
       }

--- a/src/composables/useGithubApi.ts
+++ b/src/composables/useGithubApi.ts
@@ -45,7 +45,7 @@ export function useGithubApi() {
     lastError.value = null
 
     if (!isConfigured.value) {
-      const response = await fetch('/data.json')
+      const response = await fetch(`${import.meta.env.BASE_URL}data.json`)
       if (!response.ok) {
         throw new Error('ローカルデータの読み込みに失敗しました')
       }


### PR DESCRIPTION
## Summary
- `import.meta.env.BASE_URL` を使用してベースパス `/historie-graph/` を考慮
- 修正ファイル:
  - `useGithubApi.ts` - `/data.json`
  - `useCotenRadio.ts` - `/coten-radio.json`
  - `useAffiliateLink.ts` - `/config.json`

## 問題
GitHub Pages では `/historie-graph/data.json` にアクセスする必要があるが、`/data.json` にアクセスしていたためデータ読み込みに失敗していた。

## Test plan
- [ ] マージ後、https://karaage0703.github.io/historie-graph/ でデータが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)