### PR TITLE
data: イクサガミ（今村翔吾）を作品追加

### DIFF
--- a/public/data.json
+++ b/public/data.json
@@ -2306,6 +2306,16 @@
         "550e8400-e29b-41d4-a716-446655440021",
         "china-keika-assassination"
       ]
+    },
+    {
+      "id": "ikusagami",
+      "title": "イクサガミ",
+      "type": "novel",
+      "remark": "今村翔吾。明治11年、292人の剣客が東海道を舞台にしたデスゲームに挑む。全4巻（天・地・人・神）。Netflixドラマ化（主演：岡田准一）",
+      "coverageStartYear": 1876,
+      "coverageEndYear": 1878,
+      "kindleUrl": "https://www.amazon.co.jp/dp/B0B5J1YN6Q",
+      "relatedEventIds": ["japan-meiji-start"]
     }
   ],
   "idioms": [


### PR DESCRIPTION
## 変更内容
- 作品「イクサガミ」（今村翔吾）をmediaに追加
- type: novel
- 年代: 1876-1878（明治11年、廃刀令〜の時代）
- 関連イベント: japan-meiji-start（明治時代の開始）

## 確認事項
- [x] 重複なし
- [x] 関連IDが正しい
- [x] JSONフォーマット維持（差分は追加分のみ）